### PR TITLE
0.0.2 - bugfixes and changes in empty cell calculation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,9 @@
+## 0.0.2:
+
+- Fixed error handling for `FileNotFoundError: [WinError 206] The filename or extension is too long: 'E:\\anaconda\\anaconda3\\envs\\point-eo'`. This is caused most likely by file handles running out when the cell size is small and there are a lot of cells to process.
+
+- Default verbosity is now `1`, meaning that only the progress bar is printed.
+
+- Searching for empty cells to speed up calculations used Dask previously. This caused some memory errors in combination with `rasterio.clip`. Parallelization was changed to use `joblib` instead.
+
+- Added printing of array sizes to make it easier to choose `--cell_size`

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   # DL
 
   # Geo
-  - rasterio
+  - rasterio=1.2.10
   - geopandas
   - imgaug
   - xarray

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='point_eo',
-    version='0.0.1',
+    version='0.0.2',
     packages=find_packages(include=['point_eo']),
     package_dir={'':'src'},
     entry_points={


### PR DESCRIPTION
- Fixed error handling for `FileNotFoundError: [WinError 206] The filename or extension is too long: 'E:\\anaconda\\anaconda3\\envs\\point-eo'`. This is caused most likely by file handles running out when the cell size is small and there are a lot of cells to process.

- Default verbosity is now `1`, meaning that only the progress bar is printed.

- Searching for empty cells to speed up calculations used Dask previously. This caused some memory errors in combination with `rasterio.clip`. Parallelization was changed to use `joblib` instead.

- Added printing of array sizes to make it easier to choose `--cell_size`